### PR TITLE
Restrict druid metric tags. Don't blindly include everything.

### DIFF
--- a/collectors/0/druid.py
+++ b/collectors/0/druid.py
@@ -10,6 +10,8 @@ import time
 
 from dateutil import parser as dtparser
 
+from collectors.lib import utils
+
 
 DRUID_METRICS_DIR = '/var/log/druid/metrics'
 DRUID_ROLES = [
@@ -118,6 +120,8 @@ def spawn_monitor(metric_file):
 
 
 def main():
+    utils.drop_privileges()
+
     metric_files_iter = ( DRUID_METRICS_DIR + '/' + role + '.log' for role in DRUID_ROLES )
     monitors_dict = { metric_file: None for metric_file in metric_files_iter }
 

--- a/collectors/0/druid.py
+++ b/collectors/0/druid.py
@@ -83,7 +83,7 @@ def report(line):
     if metric_specific_tags:
         tags_to_include = tags_to_include | metric_specific_tags
 
-    tags = dict((k, v) for k, v in event.iteritems() if k in tags_to_include)
+    tags = { k: v for k, v in event.iteritems() if k in tags_to_include }
 
     print format_tsd_key(metric, value, timestamp, tags)
 


### PR DESCRIPTION
@conradlee 
Some druid metric tags can have extremely high cardinality, such as guids and query contexts. This can be very bad for opentsdb.