### PR TITLE
Move common code to optimizely_utils

### DIFF
--- a/collectors/0/druid.py
+++ b/collectors/0/druid.py
@@ -11,6 +11,7 @@ import time
 from dateutil import parser as dtparser
 
 from collectors.lib import utils
+from collectors.lib.optimizely_utils import format_tsd_key
 
 
 DRUID_METRICS_DIR = '/var/log/druid/metrics'
@@ -23,47 +24,35 @@ DRUID_ROLES = [
         ]
  
 EVENT_REGEX = re.compile('Event \[(.*)\]')
-ILLEGAL_CHARS_REGEX = re.compile('[^a-zA-Z0-9\-_./]')
 
-COMMON_TAGS = set(['service', 'host'])
+COMMON_TAGS = {'service', 'host'}
 
 # Druid will revamp their metric tagging with meaningful names. Before then, refer to this link
 # https://docs.google.com/spreadsheets/d/15XxGrGv2ggdt4SnCoIsckqUNJBZ9ludyhC9hNQa3l-M/edit#gid=0
 METRIC_SPECIFIC_TAGS = {
-        'request/time':                     set(['user2', 'user4', 'user6']),
-        'server/segment/used':              set(['user1', 'user2']),
-        'server/segment/usedPercent':       set(['user1', 'user2']),
-        'server/segment/count':             set(['user1', 'user2']),
-        'server/segment/totalUsed':         set(['user2']),
-        'server/segment/totalUsedPercent':  set(['user2']),
-        'server/segment/totalCount':        set(['user2']),
-        'events/thrownAway':                set(['user2']),
-        'events/unparseable':               set(['user2']),
-        'events/processed':                 set(['user2']),
-        'rows/output':                      set(['user2']),
-        'coordinator/segment/size':         set(['user1']),
-        'coordinator/segment/count':        set(['user1']),
-        'coordinator/loadQueue/size':       set(['user1']),
-        'coordinator/loadQueue/failed':     set(['user1']),
-        'coordinator/loadQueue/count':      set(['user1']),
-        'coordinator/dropQueue/count':      set(['user1']),
-        'coordinator/segment/size':         set(['user1']),
-        'coordinator/segment/count':        set(['user1']),
-        'indexer/time/run/millis':          set(['user2', 'user3', 'user4']),
-        'indexer/segment/bytes':            set(['user2', 'user4']),
-        'indexer/segmentMoved/bytes':       set(['user2', 'user4']),
-        'indexer/segmentNuked/bytes':       set(['user2', 'user4'])
+        'request/time':                     {'user2', 'user4', 'user6'},
+        'server/segment/used':              {'user1', 'user2'},
+        'server/segment/usedPercent':       {'user1', 'user2'},
+        'server/segment/count':             {'user1', 'user2'},
+        'server/segment/totalUsed':         {'user2'},
+        'server/segment/totalUsedPercent':  {'user2'},
+        'server/segment/totalCount':        {'user2'},
+        'events/thrownAway':                {'user2'},
+        'events/unparseable':               {'user2'},
+        'events/processed':                 {'user2'},
+        'rows/output':                      {'user2'},
+        'coordinator/segment/size':         {'user1'},
+        'coordinator/segment/count':        {'user1'},
+        'coordinator/loadQueue/size':       {'user1'},
+        'coordinator/loadQueue/failed':     {'user1'},
+        'coordinator/loadQueue/count':      {'user1'},
+        'coordinator/dropQueue/count':      {'user1'},
+        'indexer/time/run/millis':          {'user2', 'user3', 'user4'},
+        'indexer/segment/bytes':            {'user2', 'user4'},
+        'indexer/segmentMoved/bytes':       {'user2', 'user4'},
+        'indexer/segmentNuked/bytes':       {'user2', 'user4'}
         }
 
-
-def format_tsd_key(metric_key, metric_value, time_, tags={}):
-    def sanitize(s):
-        return ILLEGAL_CHARS_REGEX.sub('_', str(s))
-
-    expanded_tags = ''.join([' {}={}'.format(sanitize(key), sanitize(value)) for key, value in tags.iteritems()])
-    output = '{} {} {} {}'.format(sanitize(metric_key), time_, metric_value, expanded_tags)
-    return output
- 
 
 def report(line):
     match = EVENT_REGEX.match(line.strip())

--- a/collectors/30/api_http.py
+++ b/collectors/30/api_http.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import time
-import simplejson as json
 import requests
-import re
 import sys
+
+from collectors.lib.optimizely_utils import format_tsd_key
 
 
 # Constants
@@ -31,13 +31,6 @@ def get_json(url):
     return url_json
 
 
-def format_tsd_key(metric_key, metric_value, tags={}):
-    """ Formats a key for OpenTSDB """
-    expanded_tags = ''.join([' %s=%s' % (key, value) for key, value in tags.iteritems()])
-    output = '{} {} {} {}'.format(metric_key, TIME, metric_value, expanded_tags)
-    return output
-
-
 def main():
     json = get_json(URL)
     # We only have timers now - not sure if
@@ -54,7 +47,7 @@ def main():
             for metric, value in metrics.iteritems():
                 if metric in not_metrics:
                     continue
-                print format_tsd_key(METRIC_PREFIX + metric_type + "." + metric, value, {
+                print format_tsd_key(METRIC_PREFIX + metric_type + "." + metric, value, TIME, {
                                      'class': class_name,
                                      'method': method_name})
 

--- a/collectors/30/backend_zookeeper_status_collector.py
+++ b/collectors/30/backend_zookeeper_status_collector.py
@@ -4,6 +4,8 @@ import os
 import time
 from kazoo.client import KazooClient
 
+from collectors.lib.optimizely_utils import format_tsd_key
+
 
 STATUS_ROOT = '/optimizely/status/'
 ELAPSED_SECONDS_METRICS = [
@@ -14,13 +16,6 @@ ELAPSED_SECONDS_METRICS = [
         'resultsUpload.lastStart',
         'resultsUpload.lastSuccess',
         ]
- 
-
-def format_tsd_key(metric_key, metric_value, time_, tags={}):
-    """ Formats a key for OpenTSDB """
-    expanded_tags = ''.join([' %s=%s' % (key, value) for key, value in tags.iteritems()])
-    output = '{} {} {} {}'.format(metric_key, time_, metric_value, expanded_tags)
-    return output
  
 
 def report():

--- a/collectors/30/kafka_offset_collector.py
+++ b/collectors/30/kafka_offset_collector.py
@@ -7,14 +7,10 @@ from kazoo.client import KazooClient
 from kafka import KafkaClient, SimpleConsumer
 from kafka.common import TopicAndPartition, OffsetRequest
 
+from collectors.lib.optimizely_utils import format_tsd_key
 
 # TSD UTILITIES
 
-
-def format_tsd_key(metric_key, metric_value, timestamp, tags={}):
-    expanded_tags = ''.join([' %s=%s' % (key, value) for key, value in tags.iteritems()])
-    output = '{} {} {} {}'.format(metric_key, timestamp, metric_value, expanded_tags)
-    return output
 
 def format_kafka_broker_offset_tsd_key(topic, partition, offset):
     metric = 'kafka.broker.offset'

--- a/collectors/lib/optimizely_utils.py
+++ b/collectors/lib/optimizely_utils.py
@@ -1,0 +1,13 @@
+import re
+
+
+ILLEGAL_CHARS_REGEX = re.compile('[^a-zA-Z0-9\-_./]')
+
+
+def format_tsd_key(metric_key, metric_value, time_, tags={}):
+    def sanitize(s):
+        return ILLEGAL_CHARS_REGEX.sub('_', str(s))
+
+    expanded_tags = ''.join([' {}={}'.format(sanitize(key), sanitize(value)) for key, value in tags.iteritems()])
+    output = '{} {} {} {}'.format(sanitize(metric_key), time_, metric_value, expanded_tags)
+    return output


### PR DESCRIPTION
@mdodsworth @mi-wood @arosenber @conradlee 

We have the almost the same copy of format_tsd_key all over the place. Also switch to use set literals in druid collector.