### PR TITLE
Allowing sleep interval for offset collector

### DIFF
--- a/collectors/0/secor_offset_collector.py
+++ b/collectors/0/secor_offset_collector.py
@@ -7,6 +7,7 @@ class SecorOffsetCollector(KafkaOffsetCollector):
     KAFKA_CHROOT = "/kafka"
     ZK_QUORUM = ["zookeeperHBaseProd1-1", "zookeeperHBaseProd1-2", "zookeeperHBaseProd1-3"]
     CONSUMER_GROUPS = {"secor_group"}
+    SLEEP_TIME = 30
 
     def __init__(self):
         super(SecorOffsetCollector, self).__init__()

--- a/collectors/lib/kafka_offset_collector.py
+++ b/collectors/lib/kafka_offset_collector.py
@@ -53,6 +53,7 @@ class KafkaOffsetCollector(object):
     KAFKA_CHROOT = None
     ZK_QUORUM = None
     CONSUMER_GROUPS = None
+    SLEEP_TIME = None
 
     def __init__(self):
         if self.KAFKA_CHROOT is None:
@@ -180,8 +181,9 @@ class KafkaOffsetCollector(object):
                                         "topic": topic,
                                         "partition": partition})
 
+            if self.SLEEP_TIME:
+                time.sleep(self.SLEEP_TIME)
+
         self.zk_client.stop()
         kafka_client.close()
         self.zk_client.close()
-
-


### PR DESCRIPTION
@optimizely/data-services 

Relatively small fix allowing us to pause in the collector - turns out the Secor collector was getting metrics way too aggressively and caused a lot of timestamp out of order errors.