### PR TITLE
Changing FlumeHTTP metrics to match current ones

### DIFF
--- a/collectors/0/flume.py
+++ b/collectors/0/flume.py
@@ -105,12 +105,12 @@ def main(argv):
     ts = int(time.time())  # In case last call took a while.
     stats = flume_metrics(server)
 
-    for metric in stats:
-	(component, name) = metric.split(".")
-	tags = {component.lower(): name}
-	for key,value in stats[metric].items():
-	   if key not in EXCLUDE:
-	       printmetric(component.lower(), key, value, **tags)
+    for component in stats:
+    	(component_type, name) = component.split(".")
+    	tags = {"type": name}
+    	for metric, value in stats[component].items():
+    	   if metric not in EXCLUDE:
+    	       printmetric(component_type.lower(), metric, value, **tags)
 
     time.sleep(COLLECTION_INTERVAL)
 

--- a/collectors/0/flume.py
+++ b/collectors/0/flume.py
@@ -3,17 +3,17 @@
 """
     flume stats collector
 
-Connect to flume agents over http and gather metrics 
+Connect to flume agents over http and gather metrics
 and make them suitable for OpenTSDB to consume
 
-Need to config flume-ng to spit out json formatted metrics over http 
+Need to config flume-ng to spit out json formatted metrics over http
 See http://flume.apache.org/FlumeUserGuide.html#json-reporting
 
 Tested with flume-ng 1.4.0 only. So far
 
 Based on the elastichsearch collector
 
-"""  
+"""
 
 import errno
 import httplib
@@ -92,13 +92,13 @@ def main(argv):
     err("This collector requires the `json' Python module.")
     return 1
 
-  def printmetric(metric, value, **tags):
+  def printmetric(component, metric, value, **tags):
     if tags:
       tags = " " + " ".join("%s=%s" % (name, value)
                             for name, value in tags.iteritems())
     else:
       tags = ""
-    print ("flume.%s %d %s %s" % (metric, ts, value, tags))
+    print ("flume.%s.%s %d %s %s" % (component, metric, ts, value, tags))
 
   while True:
     # Get the metrics
@@ -110,7 +110,7 @@ def main(argv):
 	tags = {component.lower(): name}
 	for key,value in stats[metric].items():
 	   if key not in EXCLUDE:
-	       printmetric(key.lower(), value, **tags)
+	       printmetric(component.lower(), key, value, **tags)
 
     time.sleep(COLLECTION_INTERVAL)
 


### PR DESCRIPTION
@optimizely/data-services 

The standard Flume collector produces metric names different than the ones we have currently. Fixed here.