### PR TITLE
Remove druidhost tag 

### DIFF
--- a/collectors/lib/druid-metrics.yaml
+++ b/collectors/lib/druid-metrics.yaml
@@ -1,7 +1,6 @@
 # common tags across all metrics
 tags:
   - service
-  - host|druidhost
 
 metrics:
   # base metrics


### PR DESCRIPTION
Remove druidhost tag as we never run multiple druid roles on the same host anyway so it doesn't give us extra information. There are 4 commonly reported tags already, and opentsdb has a limit of 8. Any metrics reported with more than 8 tags will be silently ignored...

@jchen-opt @mi-wood @ianh-optimizely 