### PR TITLE
Change aggregator to average for elb host count

### DIFF
--- a/collectors/0/cloudwatch.py
+++ b/collectors/0/cloudwatch.py
@@ -27,8 +27,8 @@ REGION_LIST = os.environ.get('CLOUDWATCH_REGION_LIST', 'us-east-1').split(',')
 
 ELB_METRICS = {
         "RequestCount": "Sum",
-        "HealthyHostCount": "Minimum",
-        "UnHealthyHostCount": "Maximum",
+        "HealthyHostCount": "Average",
+        "UnHealthyHostCount": "Average",
         "HTTPCode_ELB_5XX": "Sum",
         "HTTPCode_ELB_4XX": "Sum",
         "HTTPCode_Backend_2XX": "Sum",


### PR DESCRIPTION
Max/Min value over last 5 minutes is too spiky. Average makes more sense, which is also what AWS ELB console shows by default.

@mi-wood @mikecdavis @krishnan-chandra 