### PR TITLE
[NB-808] Fixing up Flume tcollector

### DIFF
--- a/collectors/etc/flume_conf.py
+++ b/collectors/etc/flume_conf.py
@@ -8,6 +8,5 @@ def get_settings():
   return {
     'flume_host': "localhost",     # Flume Host to Connect to
     'flume_port': 41414,            # Flume Port to connect to
-    'collection_interval': 15,      # seconds, How often to collect metric data
     'default_timeout': 10.0         # seconds
   }


### PR DESCRIPTION
@optimizely/data-services 

This PR does 2 things:

1) Makes the Flume tcollector slightly more standard by moving it under the `15` directory.
2) Returns 0 if the Flume webserver isn't found (exiting more gracefully).