### PR TITLE
Add new application type elb metrics to list

### DIFF
--- a/collectors/0/cloudwatch.py
+++ b/collectors/0/cloudwatch.py
@@ -32,7 +32,13 @@ ELB_METRICS = {
         "HTTPCode_Backend_2XX": "Sum",
         "HTTPCode_Backend_3XX": "Sum",
         "HTTPCode_Backend_4XX": "Sum",
-        "HTTPCode_Backend_5XX": "Sum"
+        "HTTPCode_Backend_5XX": "Sum",
+        "HTTPCode_ELB_4XX_Count": "Sum",
+        "HTTPCode_ELB_5XX_Count": "Sum",
+        "HTTPCode_Target_2XX_Count": "Sum",
+        "HTTPCode_Target_3XX_Count": "Sum",
+        "HTTPCode_Target_4XX_Count": "Sum",
+        "HTTPCode_Target_5XX_Count": "Sum"
     }
 
 AZS = ['us-east-1b', 'us-east-1c', 'us-east-1d', 'us-east-1e']


### PR DESCRIPTION
Noticed we didn't have any metrics for the new count client elb when trying to setup some metrics.  It appears that aws changed some of the metric names for the new application load balancer type from what they were in the classic type.  Added them to the list . Not sure if I should add tests or if there were existing tests.  Couldn't find any.  

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html