### PR TITLE
Support nested Samza metrics

### DIFF
--- a/collectors/lib/samza_metric_reporter.py
+++ b/collectors/lib/samza_metric_reporter.py
@@ -155,7 +155,7 @@ class SamzaMetricReporter:
         try:
             float(s)
             return True
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
         try:


### PR DESCRIPTION
This extends the Samza metric reporter logic to allow metrics to be
a dictionary of other metrics. This will allows us to use add Dropwizard metrics to Samza jobs where they are proxied through a Samza `Gauge` metric that carries value of a `Map<String, ? extends Number>` (see optimizely/samza-jobs#221)

Sample Samza metric snapshot message grabbed from Samza metrics topic in staging:
(Note that `processCount` is a vanilla Samza counter metric while the rest are Dropwizard metrics)
```
{
  "metrics": {
    "com.optimizely.attribution.samza.AttributionTask": {
      "processCount": 0,
      "missPastStateEvent": {
        "count": 0,
        "type": "counter"
      },
      "totalEvent": {
        "count": 0,
        "type": "counter"
      },
      "attributeAgeMs": {
        "p99": 0,
        "min": 0,
        "max": 0,
        "mean": 0,
        "count": 0,
        "p50": 0,
        "p999": 0,
        "type": "histogram",
        "stddev": 0,
        "p95": 0,
        "p98": 0,
        "p75": 0
      },
      "newVisitorEvent": {
        "count": 0,
        "type": "counter"
      }
    }
  },
  "headers": {
    "time": 1530384299075
  }
}
```

Example tcollector output:

```
attribution.metrics.processCount 1530384299 0
attribution.metrics.totalEvent.count 1530384299 0
attribution.metrics.missPastStateEvent.count 1530384299 0
attribution.metrics.newVisitorEvent.count 1530384299 0
attribution.metrics.attributeAgeMs.p98 1530384299 0
attribution.metrics.attributeAgeMs.p99 1530384299 0
attribution.metrics.attributeAgeMs.p75 1530384299 0
attribution.metrics.attributeAgeMs.max 1530384299 0
attribution.metrics.attributeAgeMs.p95 1530384299 0
attribution.metrics.attributeAgeMs.p50 1530384299 0
attribution.metrics.attributeAgeMs.count 1530384299 0
attribution.metrics.attributeAgeMs.min 1530384299 0
attribution.metrics.attributeAgeMs.stddev 1530384299 0
attribution.metrics.attributeAgeMs.p999 1530384299 0
attribution.metrics.attributeAgeMs.mean 1530384299 0
```