### PR TITLE
Josh/fix hotspotting

### DIFF
--- a/collectors/30/api_http_v2.py
+++ b/collectors/30/api_http_v2.py
@@ -13,18 +13,24 @@ METRIC_PREFIX = 'optimizely.codahale.'
 
 def main():
     json = get_json(URL)
-    res_pattern = re.compile(r"results-(\w+)")
+    res_mode_pattern = re.compile(r"results-(\w+)")
+    res_service_pattern = re.compile(r"com.optimizely(?:\.[a-z]+)+\.((?:[A-Z][a-z]+)*ResultsService)")
     metric_types = ['timers', 'meters', 'counters', 'gauges', 'histograms']
     not_metrics = ['duration_units', 'rate_units', 'units']
     for metric_type in metric_types:
         for metric, metrics in json[metric_type].iteritems():
             metric_name = "." + metric
             class_name = None
-            match = res_pattern.search(metric)
-            if match:
-                    metric_name = '.' + re.sub(res_pattern, "resultsMode", metric)
-                    class_name = match.group(1)
-            
+            res_mode_match = res_mode_pattern.search(metric)
+            res_service_match = res_service_pattern.search(metric)
+
+            if res_mode_match:
+                metric_name = '.' + re.sub(res_mode_pattern, "resultsMode", metric)
+                class_name = res_mode_match.group(1)
+            elif res_service_match:
+                metric_name = '.' + re.sub(res_service_pattern, "resultsService", metric)
+                class_name = res_service_match.group(1)
+
             for metric, value in metrics.iteritems():
                 if metric in not_metrics:
                     continue

--- a/collectors/30/api_http_v2.py
+++ b/collectors/30/api_http_v2.py
@@ -13,29 +13,41 @@ METRIC_PREFIX = 'optimizely.codahale.'
 
 def main():
     json = get_json(URL)
-    res_mode_pattern = re.compile(r"results-(\w+)")
-    res_service_pattern = re.compile(r"com.optimizely(?:\.[a-z]+)+\.((?:[A-Z][a-z]+)*ResultsService)")
+    # Matches strings such as results-resultsApi, results-composite
+    res_mode_pattern = re.compile(r"results-\w+")
+    # Matches strings such as com.optimizely.some.package.MyImpl and places a grouping around the 
+    # pacakge and simple class name.
+    res_service_pattern = re.compile(r"(com.optimizely(?:\.[a-z]+)+)\.((?:[A-Z][a-z]+)+)")
     metric_types = ['timers', 'meters', 'counters', 'gauges', 'histograms']
     not_metrics = ['duration_units', 'rate_units', 'units']
     for metric_type in metric_types:
-        for metric, metrics in json[metric_type].iteritems():
-            metric_name = "." + metric
+        for metric_class, metrics in json[metric_type].iteritems():
+            metric_name = "." + metric_class
             class_name = None
-            res_mode_match = res_mode_pattern.search(metric)
-            res_service_match = res_service_pattern.search(metric)
+            package_name = None
+            res_mode_match = res_mode_pattern.match(metric_class)
+            res_service_match = res_service_pattern.match(metric_class)
 
             if res_mode_match:
-                metric_name = '.' + re.sub(res_mode_pattern, "resultsMode", metric)
-                class_name = res_mode_match.group(1)
+                metric_name = re.sub(res_mode_pattern, '', metric_class)
+                class_name = res_mode_match.group(0)
             elif res_service_match:
-                metric_name = '.' + re.sub(res_service_pattern, "resultsService", metric)
-                class_name = res_service_match.group(1)
+                metric_name = re.sub(res_service_pattern, '', metric_class)
+                package_name= res_service_match.group(1)
+                class_name = res_service_match.group(2)
 
             for metric, value in metrics.iteritems():
                 if metric in not_metrics:
                     continue
+
+                tags = {}
+                if (class_name):
+                    tags['class'] = class_name
+                if (package_name):
+                    tags['package'] = package_name
+
                 print format_tsd_key(METRIC_PREFIX + metric_type + metric_name + '.' + metric,
-                        value, TIME, {'class': class_name} if class_name else {})
+                        value, TIME, tags)
 
 if __name__ == '__main__':
     main()

--- a/collectors/30/api_http_v2.py
+++ b/collectors/30/api_http_v2.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+import time
+import requests
+import sys
+
+from collectors.lib.optimizely_utils import format_tsd_key, get_json
+
+# Constants
+TIME = int(time.time())
+URL = 'http://127.0.0.1:8081/metrics'
+METRIC_PREFIX = 'optimizely.codahale.'
+
+def main():
+    json = get_json(URL)
+    metric_types = ['timers', 'meters', 'counters', 'gauges', 'histograms']
+    not_metrics = ['duration_units', 'rate_units', 'units']
+    for metric_type in metric_types:
+        for metric, metrics in json[metric_type].iteritems():
+            splitpath = metric.split(".")
+            if len(splitpath) == 0:
+                continue
+            elif len(splitpath) == 1:
+                class_name = splitpath[0]
+                suffix = "." + class_name
+            elif len(splitpath) > 1:
+                class_name = ".".join(splitpath[:-1])
+                method_name = splitpath[-1]
+                suffix = "." + class_name + "." + method_name
+
+            for metric, value in metrics.iteritems():
+                if metric in not_metrics:
+                    continue
+                print format_tsd_key(METRIC_PREFIX + metric_type + suffix,
+                        value, TIME, {'class': class_name})
+
+if __name__ == '__main__':
+    main()

--- a/collectors/30/api_http_v2.py
+++ b/collectors/30/api_http_v2.py
@@ -16,21 +16,19 @@ def main():
     not_metrics = ['duration_units', 'rate_units', 'units']
     for metric_type in metric_types:
         for metric, metrics in json[metric_type].iteritems():
-            splitpath = metric.split(".")
-            if len(splitpath) == 0:
-                continue
-            elif len(splitpath) == 1:
-                class_name = None
-                suffix = "." + splitpath[0]
-            elif len(splitpath) > 1:
-                class_name = ".".join(splitpath[:-1])
-                method_name = splitpath[-1]
-                suffix = "." + class_name + "." + method_name
+            class_name = None
+            split_segs = metric.split(".")
+            method_name = "." + split_segs[-1]
+            if len(split_segs) > 1:
+                if split_segs[0].startswith("results-"):
+                    class_name = split_segs[0].split("-")[1]
+                elif (len(split_segs) > 2 and split_segs[0] == "com" and split_segs[1] == "optimizely"):
+                    class_name = ".".join(split_segs[:-1])
 
             for metric, value in metrics.iteritems():
                 if metric in not_metrics:
                     continue
-                print format_tsd_key(METRIC_PREFIX + metric_type + suffix,
+                print format_tsd_key(METRIC_PREFIX + metric_type + method_name,
                         value, TIME, {'class': class_name} if class_name else {})
 
 if __name__ == '__main__':

--- a/collectors/30/api_http_v2.py
+++ b/collectors/30/api_http_v2.py
@@ -17,18 +17,20 @@ def main():
     for metric_type in metric_types:
         for metric, metrics in json[metric_type].iteritems():
             class_name = None
-            split_segs = metric.split(".")
-            method_name = "." + split_segs[-1]
+            split_segs = metric.split('.')
+            method_name = "." + metric
             if len(split_segs) > 1:
-                if split_segs[0].startswith("results-"):
-                    class_name = split_segs[0].split("-")[1]
-                elif (len(split_segs) > 2 and split_segs[0] == "com" and split_segs[1] == "optimizely"):
-                    class_name = ".".join(split_segs[:-1])
+                if split_segs[0].startswith('results-'):
+                    method_name = ".resultsMode." + split_segs[-1]
+                    class_name = split_segs[0].split('-')[1]
+                elif (len(split_segs) > 2 and split_segs[0] == "com" and split_segs[1] == 'optimizely'):
+                    method_name = '.' + split_segs[-1]
+                    class_name = '.'.join(split_segs[:-1])
 
             for metric, value in metrics.iteritems():
                 if metric in not_metrics:
                     continue
-                print format_tsd_key(METRIC_PREFIX + metric_type + method_name,
+                print format_tsd_key(METRIC_PREFIX + metric_type + method_name + '.' + metric,
                         value, TIME, {'class': class_name} if class_name else {})
 
 if __name__ == '__main__':

--- a/collectors/30/api_http_v2.py
+++ b/collectors/30/api_http_v2.py
@@ -16,21 +16,17 @@ def main():
     not_metrics = ['duration_units', 'rate_units', 'units']
     for metric_type in metric_types:
         for metric, metrics in json[metric_type].iteritems():
+            metric_name = "." + metric
             class_name = None
             split_segs = metric.split('.')
-            method_name = "." + metric
             if len(split_segs) > 1:
                 if split_segs[0].startswith('results-'):
-                    method_name = ".resultsMode." + split_segs[-1]
+                    metric_name = ".resultsMode." + '.'.join(split_segs[1:])
                     class_name = split_segs[0].split('-')[1]
-                elif (len(split_segs) > 2 and split_segs[0] == "com" and split_segs[1] == 'optimizely'):
-                    method_name = '.' + split_segs[-1]
-                    class_name = '.'.join(split_segs[:-1])
-
             for metric, value in metrics.iteritems():
                 if metric in not_metrics:
                     continue
-                print format_tsd_key(METRIC_PREFIX + metric_type + method_name + '.' + metric,
+                print format_tsd_key(METRIC_PREFIX + metric_type + metric_name + '.' + metric,
                         value, TIME, {'class': class_name} if class_name else {})
 
 if __name__ == '__main__':

--- a/collectors/30/api_http_v2.py
+++ b/collectors/30/api_http_v2.py
@@ -20,8 +20,8 @@ def main():
             if len(splitpath) == 0:
                 continue
             elif len(splitpath) == 1:
-                class_name = splitpath[0]
-                suffix = "." + class_name
+                class_name = None
+                suffix = "." + splitpath[0]
             elif len(splitpath) > 1:
                 class_name = ".".join(splitpath[:-1])
                 method_name = splitpath[-1]
@@ -31,7 +31,7 @@ def main():
                 if metric in not_metrics:
                     continue
                 print format_tsd_key(METRIC_PREFIX + metric_type + suffix,
-                        value, TIME, {'class': class_name})
+                        value, TIME, {'class': class_name} if class_name else {})
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
New version of the api_http.py tcollector.  The old version removed the more unique parts of the tsdb metric name and put them into tags.  This can lead to hotspotting with a lot of metric producers.  As we added more RSs (more Counting Service nodes) we started to crash OpenTsdb because it kept splitting the hot regions at a fast rate.

I tested this tcollector by running webtier locallly so that metrics are outputed to jmx.  I then ran the new (and old) tcollector.  It's easiest to see what's going if you look at the raw jmx metrics and then compare that to the outputs of the old and new tcollector.  
  
I attempted to extract out the `results-*`segments of the jmx metric into an open tsdb tag and replaced it with `resultsMode`.  I also extracted `com.optimizely.**.*ResultsService` classes.  This seemed to the right way to do it based on what I know about OpenTSDB.

I tested by running webttier locally so that it produced some jmx metrics.  The old tcollector would produce just 21 unqiue keys (rows).  The new one currently produces 275. If I don't extract the `resultsMode` and `resultsService` classes we get 859 unique keys (rows).  Not sure if the extra rows are worth giving up the OpenTSDB class tags.

Ideally we would have unit tests in this repo, but there is no structure for that yet.  Can revisit if desired.

[api_http_tsdb_metrics.txt](https://github.com/optimizely/tcollector/files/2168478/api_http_tsdb_metrics.txt)
[api_http_v2_tsdb_metrics.txt](https://github.com/optimizely/tcollector/files/2171584/api_http_v2_tsdb_metrics.txt)
[jmx_metrics.txt](https://github.com/optimizely/tcollector/files/2168480/jmx_metrics.txt)
