### PR TITLE
separate samza customer metric by class name depth

### DIFF
--- a/collectors/0/samza_custom_metric_prod_eet.py
+++ b/collectors/0/samza_custom_metric_prod_eet.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from multiprocessing import Process
 import sys
 
 from collectors.lib.samza_custom_metric_reporter import SamzaCustomMetricReporter
@@ -11,8 +12,16 @@ KAFKA_BOOTSTRAP_SERVERS = [
 
 
 def main():
-    reporter = SamzaCustomMetricReporter(CONSUMER_GROUP_ID, KAFKA_BOOTSTRAP_SERVERS)
-    reporter.run()
+    
+    reporter_0 = SamzaCustomMetricReporter(CONSUMER_GROUP_ID, KAFKA_BOOTSTRAP_SERVERS, depth_range=xrange(5))
+
+    reporter_1 = SamzaCustomMetricReporter(CONSUMER_GROUP_ID, KAFKA_BOOTSTRAP_SERVERS, depth_range=xrange(5, 100))
+    p = Process(target=reporter_1.run)
+    
+    p.start()
+    reporter_0.run()
+
+    p.join()
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/collectors/0/samza_custom_metric_prod_eet.py
+++ b/collectors/0/samza_custom_metric_prod_eet.py
@@ -10,7 +10,7 @@ KAFKA_BOOTSTRAP_SERVERS = [
 ]
 
 
-def main():     
+def main():
     reporter = SamzaCustomMetricReporter(CONSUMER_GROUP_ID, KAFKA_BOOTSTRAP_SERVERS, depth_range=xrange(5))
     reporter.run()
 

--- a/collectors/0/samza_custom_metric_prod_eet_1.py
+++ b/collectors/0/samza_custom_metric_prod_eet_1.py
@@ -3,15 +3,15 @@ import sys
 
 from collectors.lib.samza_custom_metric_reporter import SamzaCustomMetricReporter
 
-CONSUMER_GROUP_ID = "tcollector_samza_custom_metric_prod_eet"
+CONSUMER_GROUP_ID = "tcollector_samza_custom_metric_prod_eet_1"
 
 KAFKA_BOOTSTRAP_SERVERS = [
     "kafka-eet.us-east-1.backend-production.optimizely:9094",
 ]
 
 
-def main():     
-    reporter = SamzaCustomMetricReporter(CONSUMER_GROUP_ID, KAFKA_BOOTSTRAP_SERVERS, depth_range=xrange(5))
+def main():
+    reporter = SamzaCustomMetricReporter(CONSUMER_GROUP_ID, KAFKA_BOOTSTRAP_SERVERS, depth_range=xrange(5, 100))
     reporter.run()
 
 

--- a/collectors/lib/samza_custom_metric_reporter.py
+++ b/collectors/lib/samza_custom_metric_reporter.py
@@ -1,4 +1,3 @@
-import cProfile
 import sys
 import re
 


### PR DESCRIPTION
Newly added custom metrics like `attribution.metrics.rolloutmanager.*`, `attribution.metrics.attributeDb.httpClient.*` increases volume of custom metrics from `kafka_prod_eet`, which leads to growing lags on dashboards.

This pr separates the workload into 2 collectors, each will run in one process. I try multiprocess in one collector but process spawn can happen in the middle of print so the line is broken and can't be parsed by tcollector  